### PR TITLE
Drop testing of ruby 2.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,8 +64,3 @@ workflows:
           name: ruby2-5_rails5-2
           ruby_version: 2.5.9
           rails_version: 5.2.6
-      - bundle_lint_test:
-          name: ruby2-4_rails5-2
-          ruby_version: 2.4.10
-          rails_version: 5.2.6
-


### PR DESCRIPTION
CircleCI no longer maintains a ruby-2.4-browsers docker image which makes it hard to test.  Ruby 2.4 has been EOL for over 2 years so dropping testing while not forcing upgrade of ruby in the gemspec because ActiveFedora still supports ruby ~>2.4 in its gemspec.